### PR TITLE
Add status column and adjust OLink layout on supplier dashboard

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -132,6 +132,17 @@
         .withdraw-button {
             min-width: 100px;
         }
+
+        .o-link-wrapper {
+            display: block;
+            white-space: nowrap;
+            overflow-x: auto;
+            max-width: 260px;
+        }
+
+            .o-link-wrapper::-webkit-scrollbar {
+                height: 6px;
+            }
     </style>
 </head>
 <body>
@@ -207,8 +218,9 @@
                         <th>Country</th>
                         <th>CPI</th>
                         <th>Respondants</th>
-                        <th>OLink</th>
+                        <th class="text-nowrap">OLink</th>
                         <th>MLink</th>
+                        <th>Status</th>
                         <th>Total</th>
                         <th>Complete</th>
                         <th>Terminate</th>
@@ -234,8 +246,46 @@
                                 <td>@item.Country</td>
                                 <td>@item.CPI</td>
                                 <td>@item.Respondants</td>
-                                <td>@item.OLink</td>
+                                <td>
+                                    <div class="o-link-wrapper">@item.OLink</div>
+                                </td>
                                 <td>@item.MLink</td>
+                                @{
+                                    var status = item.Status;
+                                    var statusText = "--";
+                                    var badgeClass = "badge badge-secondary";
+                                    if (status == 1)
+                                    {
+                                        statusText = "Closed";
+                                        badgeClass = "badge badge-danger";
+                                    }
+                                    else if (status == 2)
+                                    {
+                                        statusText = "Live";
+                                        badgeClass = "badge badge-success";
+                                    }
+                                    else if (status == 3)
+                                    {
+                                        statusText = "On Hold";
+                                        badgeClass = "badge badge-warning";
+                                    }
+                                    else if (status == 4)
+                                    {
+                                        statusText = "Cancelled";
+                                        badgeClass = "badge badge-danger";
+                                    }
+                                    else if (status == 5)
+                                    {
+                                        statusText = "Awarded";
+                                        badgeClass = "badge badge-info";
+                                    }
+                                    else if (status == 6)
+                                    {
+                                        statusText = "Invoiced";
+                                        badgeClass = "badge badge-default";
+                                    }
+                                }
+                                <td><span class="@badgeClass">@statusText</span></td>
                                 <td>@item.Total</td>
                                 <td>@item.Complete</td>
                                 <td>@item.Terminate</td>
@@ -406,16 +456,77 @@
             XLSX.writeFile(wb, fileName);
         }
 
+        function getStatusText(status) {
+            const value = parseInt(status, 10);
+            if (isNaN(value)) {
+                return "--";
+            }
+
+            switch (value) {
+                case 1:
+                    return "Closed";
+                case 2:
+                    return "Live";
+                case 3:
+                    return "On Hold";
+                case 4:
+                    return "Cancelled";
+                case 5:
+                    return "Awarded";
+                case 6:
+                    return "Invoiced";
+                default:
+                    return "--";
+            }
+        }
+
+        function getStatusBadge(status) {
+            const text = getStatusText(status);
+            let badgeClass = "badge badge-secondary";
+
+            const value = parseInt(status, 10);
+            switch (value) {
+                case 1:
+                    badgeClass = "badge badge-danger";
+                    break;
+                case 2:
+                    badgeClass = "badge badge-success";
+                    break;
+                case 3:
+                    badgeClass = "badge badge-warning";
+                    break;
+                case 4:
+                    badgeClass = "badge badge-danger";
+                    break;
+                case 5:
+                    badgeClass = "badge badge-info";
+                    break;
+                case 6:
+                    badgeClass = "badge badge-default";
+                    break;
+                default:
+                    badgeClass = "badge badge-secondary";
+                    break;
+            }
+
+            return `<span class="${badgeClass}">${text}</span>`;
+        }
+
         function convertDataToArray(allData, headers1) {
 
             excludeColumns = ["projectName", "projectMappingId", "projectId", "supplierId", "supplierName"];
 
             //const headers = Object.keys(allData[0]).filter(header => !excludeColumns.includes(header));
-            const headers = ["pid", "country", "cpi", "respondants", "oLink", "mLink", "total", "complete", "terminate", "overquota", "securityTerm", "fraudError", "incomplete", "loi", "irPercent", "notes"];
+            const headers = ["pid", "country", "cpi", "respondants", "oLink", "mLink", "status", "total", "complete", "terminate", "overquota", "securityTerm", "fraudError", "incomplete", "loi", "irPercent", "notes"];
 
             // Convert data to an array of arrays, excluding specified columns
-            const data = allData.map(row => headers.map(header => row[header]));
-            const displayHeaders = ["Project Number", "Country", "CPI", "Respondants", "OLink", "MLink", "Total", "Complete", "Terminate", "Overquota", "Security Term", "Fraud Error", "Incomplete", "LOI", "IR Percent", "Notes"];
+            const data = allData.map(row => headers.map(header => {
+                if (header === "status") {
+                    return getStatusText(row[header]);
+                }
+                return row[header];
+            }));
+            const displayHeaders = ["Project Number", "Country", "CPI", "Respondants", "OLink", "MLink", "Status", "Total", "Complete", "Terminate", "Overquota", "Security Term", "Fraud Error", "Incomplete", "LOI", "IR Percent", "Notes"];
             // Add headers as the first row
             return [displayHeaders, ...data];
         }
@@ -550,8 +661,32 @@
                     { "data": "country" },
                     { "data": "cpi" },
                     { "data": "respondants" },
-                    { "data": "oLink" },
+                    {
+                        "data": "oLink",
+                        "render": function (data, type) {
+                            if (type !== 'display') {
+                                return data || "";
+                            }
+                            if (!data) {
+                                return "";
+                            }
+                            return `<div class="o-link-wrapper">${data}</div>`;
+                        }
+                    },
                     { "data": "mLink" },
+                    {
+                        "data": "status",
+                        "render": function (data, type) {
+                            if (type === 'display') {
+                                return getStatusBadge(data);
+                            }
+                            if (type === 'filter') {
+                                return getStatusText(data);
+                            }
+                            const value = parseInt(data, 10);
+                            return isNaN(value) ? 0 : value;
+                        }
+                    },
                     { "data": "total" },
                     { "data": "complete" },
                     { "data": "terminate" },

--- a/src/NextOnServices/NextOnServices.Endpoints/Suppliers/Controllers/SuppliersAPIController.cs
+++ b/src/NextOnServices/NextOnServices.Endpoints/Suppliers/Controllers/SuppliersAPIController.cs
@@ -85,7 +85,7 @@ public class SuppliersAPIController : ControllerBase
     {
         try
         {
-            string sQuery = "WITH SupplierCounts AS (\r\n    SELECT \r\n        pm.ID ProjectMappingId,\r\n        pm.ProjectID ProjectId,\r\n        pm.SupplierID SupplierId,\r\n        s.Name SupplierName,\r\n        p.PName ProjectName,\r\n        cm.Country,\r\n        pm.CPI,\r\n        pm.Respondants,\r\n        COUNT(sp.Status) AS Total,\r\n        SUM(CASE WHEN sp.Status = 'Complete' THEN 1 ELSE 0 END) AS Complete,\r\n        SUM(CASE WHEN sp.Status = 'Terminate' THEN 1 ELSE 0 END) AS Terminate,\r\n        SUM(CASE WHEN sp.Status = 'OVERQUOTA' THEN 1 ELSE 0 END) AS Overquota,\r\n        SUM(CASE WHEN sp.Status = 'SEC_TERM' THEN 1 ELSE 0 END) AS SecurityTerm,\r\n        SUM(CASE WHEN sp.Status = 'F_ERROR' THEN 1 ELSE 0 END) AS FraudError,\r\n        SUM(CASE WHEN sp.Status = 'InComplete' THEN 1 ELSE 0 END) AS Incomplete,\r\n\t\tLOI = AVG(CASE \r\n                    WHEN sp.Status = 'Complete' AND sp.StartDate IS NOT NULL AND sp.EndDate IS NOT NULL \r\n                    THEN DATEDIFF(MINUTE, sp.StartDate, sp.EndDate) \r\n                    ELSE NULL \r\n                  END)\r\n    FROM \r\n        ProjectMapping pm\r\n    JOIN \r\n        Projects p ON pm.ProjectID = p.ProjectId\r\n    JOIN \r\n        Suppliers s ON pm.SupplierID = s.ID\r\n    JOIN \r\n        CountryMaster cm ON pm.CountryID = cm.CountryId\r\n    LEFT JOIN \r\n        SupplierProjects sp ON sp.SID = pm.SID\r\n    WHERE \r\n        pm.SupplierID = @SupplierID \r\n        AND p.IsActive = 1 \r\n        AND s.IsActive = 1\r\n    GROUP BY \r\n        pm.ID, pm.ProjectID, pm.SupplierID, s.Name, p.PName, cm.Country, pm.CPI, pm.Respondants\r\n)\r\nSELECT *,\r\n    IRPercent = CASE \r\n        WHEN (Complete + Terminate) = 0 OR Complete = 0 THEN 0\r\n        ELSE CAST(Complete * 100.0 / (Complete + Terminate) AS DECIMAL(10, 2))\r\n    END \r\nFROM SupplierCounts order by ProjectName;\r\n";
+            string sQuery = "WITH SupplierCounts AS (\r\n    SELECT \r\n        pm.ID ProjectMappingId,\r\n        pm.ProjectID ProjectId,\r\n        pm.SupplierID SupplierId,\r\n        s.Name SupplierName,\r\n        p.PName ProjectName,\r\n        p.STATUS Status,\r\n        cm.Country,\r\n        pm.CPI,\r\n        pm.Respondants,\r\n        COUNT(sp.Status) AS Total,\r\n        SUM(CASE WHEN sp.Status = 'Complete' THEN 1 ELSE 0 END) AS Complete,\r\n        SUM(CASE WHEN sp.Status = 'Terminate' THEN 1 ELSE 0 END) AS Terminate,\r\n        SUM(CASE WHEN sp.Status = 'OVERQUOTA' THEN 1 ELSE 0 END) AS Overquota,\r\n        SUM(CASE WHEN sp.Status = 'SEC_TERM' THEN 1 ELSE 0 END) AS SecurityTerm,\r\n        SUM(CASE WHEN sp.Status = 'F_ERROR' THEN 1 ELSE 0 END) AS FraudError,\r\n        SUM(CASE WHEN sp.Status = 'InComplete' THEN 1 ELSE 0 END) AS Incomplete,\r\n\t\tLOI = AVG(CASE \r\n                    WHEN sp.Status = 'Complete' AND sp.StartDate IS NOT NULL AND sp.EndDate IS NOT NULL \r\n                    THEN DATEDIFF(MINUTE, sp.StartDate, sp.EndDate) \r\n                    ELSE NULL \r\n                  END)\r\n    FROM \r\n        ProjectMapping pm\r\n    JOIN \r\n        Projects p ON pm.ProjectID = p.ProjectId\r\n    JOIN \r\n        Suppliers s ON pm.SupplierID = s.ID\r\n    JOIN \r\n        CountryMaster cm ON pm.CountryID = cm.CountryId\r\n    LEFT JOIN \r\n        SupplierProjects sp ON sp.SID = pm.SID\r\n    WHERE \r\n        pm.SupplierID = @SupplierID \r\n        AND p.IsActive = 1 \r\n        AND s.IsActive = 1\r\n    GROUP BY \r\n        pm.ID, pm.ProjectID, pm.SupplierID, s.Name, p.PName, p.STATUS, cm.Country, pm.CPI, pm.Respondants\r\n)\r\nSELECT *,\r\n    IRPercent = CASE \r\n        WHEN (Complete + Terminate) = 0 OR Complete = 0 THEN 0\r\n        ELSE CAST(Complete * 100.0 / (Complete + Terminate) AS DECIMAL(10, 2))\r\n    END \r\nFROM SupplierCounts order by ProjectName;\r\n";
             //var sParam = new { @SupplierID = SupplierId };
 
             var orderDirection = orderByDirection.ToLower() == "desc" ? "DESC" : "ASC";
@@ -126,6 +126,7 @@ public class SuppliersAPIController : ControllerBase
                     pm.SupplierID SupplierId,
                     s.Name SupplierName,
                     p.PName ProjectName,
+                    p.STATUS Status,
                     cm.Country,
                     pm.CPI,
                     pm.Respondants,
@@ -158,7 +159,7 @@ public class SuppliersAPIController : ControllerBase
                     AND s.IsActive = 1
                     AND (p.PName LIKE '%' + @SearchValue + '%' OR cm.Country LIKE '%' + @SearchValue + '%')  
                 GROUP BY 
-                    pm.ID, pm.ProjectID, pm.SupplierID, s.Name, p.PName, cm.Country, pm.CPI, pm.Respondants,pm.IsChecked
+                    pm.ID, pm.ProjectID, pm.SupplierID, s.Name, p.PName, p.STATUS, cm.Country, pm.CPI, pm.Respondants,pm.IsChecked
             ORDER BY " + orderByColumnName + " " + orderDirection + @"
             OFFSET @Offset ROWS FETCH NEXT @PageSize ROWS ONLY
             )
@@ -225,6 +226,7 @@ public class SuppliersAPIController : ControllerBase
                     pm.SupplierID SupplierId,
                     s.Name SupplierName,
                     p.PName ProjectName,
+                    p.STATUS Status,
                     p.PID,
                     cm.Country,
                     pm.CPI,
@@ -260,7 +262,7 @@ public class SuppliersAPIController : ControllerBase
                     AND p.IsActive = 1 
                     AND s.IsActive = 1                    
                 GROUP BY 
-                    pm.ID, pm.ProjectID, pm.SupplierID, s.Name, p.PName, cm.Country, pm.CPI, pm.Respondants,pm.IsChecked,p.PID,pm.Notes,pm.OLink,pm.MLink            
+                    pm.ID, pm.ProjectID, pm.SupplierID, s.Name, p.PName, p.STATUS, cm.Country, pm.CPI, pm.Respondants,pm.IsChecked,p.PID,pm.Notes,pm.OLink,pm.MLink            
             ),
             SupplierCountsWithIR as (SELECT *, 
                 IRPercent = CASE 

--- a/src/NextOnServices/NextOnServices.Infrastructure/ViewModels/Supplier/SupplierProjectsDTO.cs
+++ b/src/NextOnServices/NextOnServices.Infrastructure/ViewModels/Supplier/SupplierProjectsDTO.cs
@@ -27,6 +27,7 @@ public class SupplierProjectsDTO
     public decimal? LOI { get; set; }
     public decimal? IRPercent { get; set; }
     public int? ProjectMappingChecked { get; set; }
+    public int? Status { get; set; }
     public string? Notes { get; set; }
     public string? OLink { get; set; }
     public string? MLink { get; set; }


### PR DESCRIPTION
## Summary
- include the project status field in supplier project queries and DTOs
- display the status badge on the supplier dashboard table and keep OLink values on a single line with scrolling support
- update client-side exports and rendering logic to handle the new status column

## Testing
- `dotnet build NextOnServices.sln` *(fails: dotnet command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de2f1bea648322883efe03b697cc1f