### PR TITLE
Add status badges and improve supplier dashboard link display

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -134,10 +134,24 @@
         }
 
         .cell-scroll {
-            display: block !important;
-            max-width: 280px !important; /* set the visible width you want */
-            white-space: nowrap !important; /* single line */
-            overflow-x: auto ; /* scrollbar if too long */
+            max-width: 280px;
+            white-space: nowrap;
+            overflow-x: auto;
+            overflow-y: hidden;
+        }
+
+            .cell-scroll a {
+                color: inherit;
+                text-decoration: none;
+                white-space: nowrap;
+                display: inline-block;
+            }
+
+        .status-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 90px;
         }
     </style>
 </head>
@@ -215,6 +229,7 @@
                         <th>Country</th>
                         <th>CPI</th>
                         <th>Respondants</th>
+                        <th>Status</th>
                         <th>OLink</th>
                         @* <th>MLink</th> *@
                         <th>Total</th>
@@ -243,7 +258,45 @@
                                 <td>@item.Country</td>
                                 <td>@item.CPI</td>
                                 <td>@item.Respondants</td>
-                                <td class="cell-scroll">@item.OLink</td>
+                                <td>
+                                    @{
+                                        var statusValue = item.Status ?? 0;
+                                        var statusText = "-";
+                                        var statusClass = "badge badge-secondary";
+
+                                        switch (statusValue)
+                                        {
+                                            case 1:
+                                                statusText = "Closed";
+                                                statusClass = "badge badge-danger";
+                                                break;
+                                            case 2:
+                                                statusText = "Live";
+                                                statusClass = "badge badge-success";
+                                                break;
+                                            case 3:
+                                                statusText = "On Hold";
+                                                statusClass = "badge badge-warning";
+                                                break;
+                                            case 4:
+                                                statusText = "Cancelled";
+                                                statusClass = "badge badge-danger";
+                                                break;
+                                            case 5:
+                                                statusText = "Awarded";
+                                                statusClass = "badge badge-info";
+                                                break;
+                                            case 6:
+                                                statusText = "Invoiced";
+                                                statusClass = "badge badge-default";
+                                                break;
+                                        }
+                                    }
+                                    <span class="status-badge @statusClass">@statusText</span>
+                                </td>
+                                <td>
+                                    <div class="cell-scroll" title="@item.OLink">@item.OLink</div>
+                                </td>
                                 @* <td>@item.MLink</td> *@
                                 <td>@item.Total</td>
                                 <td>@item.Complete</td>
@@ -420,11 +473,11 @@
             excludeColumns = ["projectName", "projectMappingId", "projectId", "supplierId", "supplierName"];
 
             //const headers = Object.keys(allData[0]).filter(header => !excludeColumns.includes(header));
-            const headers = ["pid", "country", "cpi", "respondants", "oLink", "mLink", "total", "complete", "terminate", "overquota", "securityTerm", "fraudError", "incomplete", "loi", "irPercent", "notes"];
+            const headers = ["pid", "country", "cpi", "respondants", "status", "oLink", "mLink", "total", "complete", "terminate", "overquota", "securityTerm", "fraudError", "incomplete", "loi", "irPercent", "notes"];
 
             // Convert data to an array of arrays, excluding specified columns
             const data = allData.map(row => headers.map(header => row[header]));
-            const displayHeaders = ["Project Number", "Country", "CPI", "Respondants", "OLink", "MLink", "Total", "Complete", "Terminate", "Overquota", "Security Term", "Fraud Error", "Incomplete", "LOI", "IR Percent", "Notes"];
+            const displayHeaders = ["Project Number", "Country", "CPI", "Respondants", "Status", "OLink", "MLink", "Total", "Complete", "Terminate", "Overquota", "Security Term", "Fraud Error", "Incomplete", "LOI", "IR Percent", "Notes"];
             // Add headers as the first row
             return [displayHeaders, ...data];
         }
@@ -560,7 +613,42 @@
                     { "data": "country" },
                     { "data": "cpi" },
                     { "data": "respondants" },
-                    { "data": "oLink" },
+                    {
+                        "data": "status",
+                        "render": function (data, type) {
+                            if (type !== 'display') {
+                                return data;
+                            }
+
+                            const statusValue = parseInt(data, 10);
+                            const statusMap = {
+                                1: { text: 'Closed', className: 'badge badge-danger' },
+                                2: { text: 'Live', className: 'badge badge-success' },
+                                3: { text: 'On Hold', className: 'badge badge-warning' },
+                                4: { text: 'Cancelled', className: 'badge badge-danger' },
+                                5: { text: 'Awarded', className: 'badge badge-info' },
+                                6: { text: 'Invoiced', className: 'badge badge-default' }
+                            };
+
+                            const statusInfo = statusMap[statusValue] || { text: '-', className: 'badge badge-secondary' };
+                            return `<span class="status-badge ${statusInfo.className}">${statusInfo.text}</span>`;
+                        }
+                    },
+                    {
+                        "data": "oLink",
+                        "render": function (data, type) {
+                            if (!data) {
+                                return '';
+                            }
+
+                            if (type !== 'display') {
+                                return data;
+                            }
+
+                            const safeText = $('<div>').text(data).html();
+                            return `<div class="cell-scroll" title="${safeText}">${safeText}</div>`;
+                        }
+                    },
                     // { "data": "mLink" },
                     { "data": "total" },
                     { "data": "complete" },


### PR DESCRIPTION
## Summary
- add the VT dashboard style status badge column to the supplier dashboard table
- keep OLink values on a single line with horizontal scrolling and include the status data in exports

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de35ae9000832292e5806bf8fedb07