### PR TITLE
Normalize supplier OLink display

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -292,7 +292,16 @@
                                 <td>@item.CPI</td>
                                 <td>@item.Respondants</td>
                                 <td>
-                                    <div class="cell-scroll" title="@item.OLink">@item.OLink</div>
+                                    @{
+                                        var oLinkDisplay = string.IsNullOrWhiteSpace(item.OLink)
+                                            ? string.Empty
+                                            : item.OLink
+                                                .Replace("\r\n", " ")
+                                                .Replace("\n", " ")
+                                                .Replace("\r", " ")
+                                                .Trim();
+                                    }
+                                    <div class="cell-scroll" title="@oLinkDisplay">@oLinkDisplay</div>
                                 </td>
                                 @* <td>@item.MLink</td> *@
                                 <td>@item.Total</td>


### PR DESCRIPTION
## Summary
- remove line breaks from supplier OLink values before rendering so table entries stay on one line

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de602e67188322bdc881e0cb41cdcc