### PR TITLE
Ensure Supplier dashboard OLink and Country display on single line

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -133,18 +133,19 @@
             min-width: 100px;
         }
 
-        .cell-scroll {
-            max-width: 280px;
+        .cell-nowrap {
+            display: block;
+            max-width: 100%;
             white-space: nowrap;
-            overflow-x: auto;
-            overflow-y: hidden;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
-            .cell-scroll a {
+            .cell-nowrap a {
                 color: inherit;
                 text-decoration: none;
                 white-space: nowrap;
-                display: inline-block;
+                display: inline;
             }
 
         .status-badge {
@@ -288,20 +289,25 @@
                                     <span class="status-badge @statusClass">@statusText</span>
                                 </td>
                                 <td>@item.PID</td>
-                                <td>@item.Country</td>
+                                <td>
+                                    @{
+                                        var countryDisplay = string.IsNullOrWhiteSpace(item.Country)
+                                            ? string.Empty
+                                            : System.Text.RegularExpressions.Regex.Replace(item.Country, "\\s+", " ")
+                                                .Trim();
+                                    }
+                                    <div class="cell-nowrap" title="@countryDisplay">@countryDisplay</div>
+                                </td>
                                 <td>@item.CPI</td>
                                 <td>@item.Respondants</td>
                                 <td>
                                     @{
                                         var oLinkDisplay = string.IsNullOrWhiteSpace(item.OLink)
                                             ? string.Empty
-                                            : item.OLink
-                                                .Replace("\r\n", " ")
-                                                .Replace("\n", " ")
-                                                .Replace("\r", " ")
+                                            : System.Text.RegularExpressions.Regex.Replace(item.OLink, "\\s+", " ")
                                                 .Trim();
                                     }
-                                    <div class="cell-scroll" title="@oLinkDisplay">@oLinkDisplay</div>
+                                    <div class="cell-nowrap" title="@oLinkDisplay">@oLinkDisplay</div>
                                 </td>
                                 @* <td>@item.MLink</td> *@
                                 <td>@item.Total</td>
@@ -636,7 +642,21 @@
                         }
                     },
                     { "data": "pid" },
-                    { "data": "country" },
+                    {
+                        "data": "country",
+                        "render": function (data, type) {
+                            if (!data) {
+                                return '';
+                            }
+
+                            if (type !== 'display') {
+                                return data;
+                            }
+
+                            const safeText = $('<div>').text(data).html().replace(/\s+/g, ' ').trim();
+                            return `<div class="cell-nowrap" title="${safeText}">${safeText}</div>`;
+                        }
+                    },
                     { "data": "cpi" },
                     { "data": "respondants" },
                     {
@@ -650,8 +670,8 @@
                                 return data;
                             }
 
-                            const safeText = $('<div>').text(data).html();
-                            return `<div class="cell-scroll" title="${safeText}">${safeText}</div>`;
+                            const safeText = $('<div>').text(data).html().replace(/\s+/g, ' ').trim();
+                            return `<div class="cell-nowrap" title="${safeText}">${safeText}</div>`;
                         }
                     },
                     // { "data": "mLink" },


### PR DESCRIPTION
## Summary
- normalise the supplier dashboard country and OLink values to collapse whitespace and render without scrollbars
- replace the scrolling cell style with a reusable nowrap ellipsis presentation for single line display
- update the DataTables renderers so dynamic rows share the same single-line treatment and tooltips

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de667e14288322b25aec420aab64f5