### PR TITLE
Fix custom script paths to enable dashboard status updates

### DIFF
--- a/src/NextOnServices.WebUI/Areas/GRP/Views/Shared/_Layout.cshtml
+++ b/src/NextOnServices.WebUI/Areas/GRP/Views/Shared/_Layout.cshtml
@@ -408,7 +408,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 
-    <script src="~/customjs/common.js"></script>
+    <script src="~/customJS/Common.js"></script>
     <!-- End custom js for this page-->
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/NextOnServices.WebUI/Areas/GRP/Views/Shared/_LayoutWOMenus.cshtml
+++ b/src/NextOnServices.WebUI/Areas/GRP/Views/Shared/_LayoutWOMenus.cshtml
@@ -446,7 +446,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 
-    <script src="~/customjs/common.js"></script>
+    <script src="~/customJS/Common.js"></script>
     <!-- End custom js for this page-->
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Client/AddClient.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Client/AddClient.cshtml
@@ -89,7 +89,7 @@
 
 
 @section scripts {
-    <script src="~/customjs/validation.js"></script>
+    <script src="~/customJS/Validation.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             $(".select2").select2();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Home/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Home/Dashboard.cshtml
@@ -287,7 +287,7 @@
 </div>
 
 @section scripts {
-    <script src="~/customjs/home/dashboard.js"></script>
+    <script src="~/customJS/Home/Dashboard.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             // BlockUI();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Home/ProjectPage.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Home/ProjectPage.cshtml
@@ -1092,7 +1092,7 @@
 @section scripts {
 
 
-    <script src="~/customjs/home/dashboard.js"></script>
+    <script src="~/customJS/Home/Dashboard.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             MappedCountriesView();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/ProjectMapping/ProjectMapping.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/ProjectMapping/ProjectMapping.cshtml
@@ -46,7 +46,7 @@
 <input type="hidden" asp-for="ProjectMappingWithChild.encProjectId" />
 @section scripts {
     
-    <script src="~/customjs/projectmapping/projectmapping.js"></script>
+    <script src="~/customJS/ProjectMapping/ProjectMapping.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             AddProjectMappingPartialView();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/ProjectURLs/ProjectUrls.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/ProjectURLs/ProjectUrls.cshtml
@@ -45,7 +45,7 @@
 
 <input type="hidden" asp-for="ProjectsURL.encProjectId" />
 @section scripts {
-    <script src="~/customjs/projectsurl/projectsurl.js"></script>
+    <script src="~/customJS/ProjectsURL/ProjectsURL.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             AddProjectURLPartialView();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Shared/_Layout.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Shared/_Layout.cshtml
@@ -549,7 +549,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 
-    <script src="~/customjs/common.js"></script>
+    <script src="~/customJS/Common.js"></script>
     <!-- End custom js for this page-->
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/AddSupplier.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/AddSupplier.cshtml
@@ -134,7 +134,7 @@
 
 
 @section scripts {
-    <script src="~/customjs/validation.js"></script>
+    <script src="~/customJS/Validation.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             $(".select2").select2();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -356,7 +356,7 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-    <script src="~/customjs/common.js"></script>
+    <script src="~/customJS/Common.js"></script>
     <script>
         var table;
         $(document).ready(function () {

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/EditProfile-old.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/EditProfile-old.cshtml
@@ -247,7 +247,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 
-    <script src="~/customjs/validation.js"></script>
+    <script src="~/customJS/Validation.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             $(".select2").select2();

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Profile.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Profile.cshtml
@@ -544,8 +544,8 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js"></script>
 
-    <script src="~/customjs/supplier/editprofile.js"></script>
-    <script src="~/customjs/common.js"></script>
+    <script src="~/customJS/Supplier/EditProfile.js"></script>
+    <script src="~/customJS/Common.js"></script>
     <script>
         // JavaScript to toggle between display and edit mode for all fields
 

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/SupplierCountryPanelSize.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/SupplierCountryPanelSize.cshtml
@@ -13,7 +13,7 @@
 
 <input type="hidden" asp-for="encId" />
 @section scripts {
-    <script src="~/customjs/Supplier/SupplierCountryPanelSize.js"></script>
+    <script src="~/customJS/Supplier/SupplierCountryPanelSize.js"></script>
     <script type="text/javascript">
         $(document).ready(function () {
             AddSupplierCountryPanelSizePartialView();

--- a/src/NextOnServices.WebUI/Views/Shared/_Layout.cshtml
+++ b/src/NextOnServices.WebUI/Views/Shared/_Layout.cshtml
@@ -481,7 +481,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.blockUI/2.70/jquery.blockUI.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 
-    <script src="~/customjs/common.js"></script>
+    <script src="~/customJS/Common.js"></script>
     <!-- End custom js for this page-->
     @await RenderSectionAsync("Scripts", required: false)
 </body>


### PR DESCRIPTION
## Summary
- load the dashboard status-change script using the correct case-sensitive path so clicking the status badge opens the modal
- update other views and layouts to reference the actual customJS directory casing, preventing missing custom script files across the site

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df97420ea0832281cb3bafeaa9c449