### PR TITLE
Make dashboard status badges open change modal

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Home/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Home/Dashboard.cshtml
@@ -257,7 +257,7 @@
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="exampleModalLongTitle">Change Projects Status</h5>
+                    <h5 class="modal-title" id="exampleModalLongTitle">Change Project Status <span class="text-muted font-weight-normal current-status"></span></h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
@@ -294,6 +294,9 @@
             // return;
             $("select").select2();
             getProjectTable();
+            $("#mdlChangeStatus").on('hidden.bs.modal', function () {
+                $(this).find(".modal-title span.current-status").text('');
+            });
         });
 
         function getProjectTable() {

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Home/_Dashboard/_ProjectTable.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Home/_Dashboard/_ProjectTable.cshtml
@@ -10,6 +10,15 @@
     .tblstatus {
         cursor: pointer;
     }
+
+    .badge.tblstatus {
+        border: none;
+        outline: none;
+    }
+
+    .badge.tblstatus:focus {
+        box-shadow: none;
+    }
 </style>
 <table class="table table-striped table-borderless">
     <thead>
@@ -62,27 +71,27 @@
                                     @{
                                         if (item.STATUS == 1)
                                         {
-                                            <div class="badge badge-danger"><span onclick="openChangeStatusBox('Closed',@item.ProjectId)" class="hvr-grow tblstatus">Closed</span></div>
+                                            <button type="button" class="badge badge-danger hvr-grow tblstatus" onclick="openChangeStatusBox(1,@item.ProjectId,'Closed')">Closed</button>
                                         }
                                         if (item.STATUS == 2)
                                         {
-                                            <div class="badge badge-success"><span onclick="openChangeStatusBox('Live',@item.ProjectId)" class="hvr-grow tblstatus">Live</span></div>
+                                            <button type="button" class="badge badge-success hvr-grow tblstatus" onclick="openChangeStatusBox(2,@item.ProjectId,'Live')">Live</button>
                                         }
                                         if (item.STATUS == 3)
                                         {
-                                            <div class="badge badge-warning"><span onclick="openChangeStatusBox('On Hold',@item.ProjectId)" class="hvr-grow tblstatus">On Hold</span></div>
+                                            <button type="button" class="badge badge-warning hvr-grow tblstatus" onclick="openChangeStatusBox(3,@item.ProjectId,'On Hold')">On Hold</button>
                                         }
                                         if (item.STATUS == 4)
                                         {
-                                            <div class="badge badge-danger"><span onclick="openChangeStatusBox('Cancelled',@item.ProjectId)" class="hvr-grow tblstatus">Cancelled</span></div>
+                                            <button type="button" class="badge badge-danger hvr-grow tblstatus" onclick="openChangeStatusBox(4,@item.ProjectId,'Cancelled')">Cancelled</button>
                                         }
                                         if (item.STATUS == 5)
                                         {
-                                            <div class="badge badge-info"><span onclick="openChangeStatusBox('Awarded',@item.ProjectId)" class="hvr-grow tblstatus">Awarded</span></div>
+                                            <button type="button" class="badge badge-info hvr-grow tblstatus" onclick="openChangeStatusBox(5,@item.ProjectId,'Awarded')">Awarded</button>
                                         }
                                         if (item.STATUS == 6)
                                         {
-                                            <div class="badge badge-default"><span onclick="openChangeStatusBox('Invoiced',@item.ProjectId)" class="hvr-grow tblstatus">Invoiced</span></div>
+                                            <button type="button" class="badge badge-default hvr-grow tblstatus" onclick="openChangeStatusBox(6,@item.ProjectId,'Invoiced')">Invoiced</button>
                                         }
                                     }
                                 </td>

--- a/src/NextOnServices.WebUI/wwwroot/customJS/Home/Dashboard.js
+++ b/src/NextOnServices.WebUI/wwwroot/customJS/Home/Dashboard.js
@@ -30,12 +30,13 @@
     });
 }
 
-function openChangeStatusBox(status, projectId) {
+function openChangeStatusBox(statusId, projectId, statusLabel) {
     $("#mdlChangeStatus").modal('show');
-    let statusId = status == "Closed" ? 1 : status == "Live" ? 2 : status == "On Hold" ? 3 : status == "Cancelled" ? 4 : status == "Awarded" ? 5 : status == "Invoiced" ? 6 : 0;
-    $("#mdlChangeStatus").find("[name='Status']").val(statusId);
+    $("#mdlChangeStatus").find("[name='Status']").val(statusId).trigger('change');
     $("#mdlChangeStatus").find("[name='ProjectId']").val(projectId);
 
+    var statusText = statusLabel ? '(' + statusLabel + ')' : '';
+    $("#mdlChangeStatus").find(".modal-title span.current-status").text(statusText);
 }
 
 function UpdateStatus() {


### PR DESCRIPTION
## Summary
- render project status badges as clickable buttons that trigger the change-status modal
- simplify the client script to accept a status id and display the selected status inside the modal header
- reset the modal header when the dialog closes and tweak badge styling for button usage

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e170e7be908322ae73651f252b82a2