### PR TITLE
Fix dashboard status update flow

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Controllers/HomeController.cs
+++ b/src/NextOnServices.WebUI/Areas/VT/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿
 using ClosedXML.Excel;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 using NextOnServices.Endpoints.Accounts;
@@ -147,9 +148,17 @@ public class HomeController : Controller
     {
         return View();
     }
+    [HttpPost]
     public async Task<IActionResult> ChangeProjectStatus(int Status, int ProjectId)
     {
         IActionResult res = await _projectsAPIController.ChangeProjectStatus(Status, ProjectId);
+
+        if (res is ObjectResult objectResult)
+        {
+            int statusCode = objectResult.StatusCode ?? StatusCodes.Status200OK;
+            return StatusCode(statusCode, objectResult.Value);
+        }
+
         return res;
     }
 

--- a/src/NextOnServices.WebUI/wwwroot/customJS/Home/Dashboard.js
+++ b/src/NextOnServices.WebUI/wwwroot/customJS/Home/Dashboard.js
@@ -49,10 +49,16 @@ function UpdateStatus() {
         cache: false,
         dataType: "json",
         success: function (data) {
-            $("#mdlChangeStatus").modal('hide');
-            getProjectTablePartialView().then(() => {
+            if (data && data.success) {
+                $("#mdlChangeStatus").modal('hide');
+                getProjectTablePartialView().then(() => {
+                    UnblockUI();
+                });
+            }
+            else {
                 UnblockUI();
-            });
+                alert("Error!", "Unable to update project status.");
+            }
         },
         error: function (result) {
             UnblockUI();

--- a/src/NextOnServices/NextOnServices.Endpoints/Projects/Controllers/ProjectsAPIController.cs
+++ b/src/NextOnServices/NextOnServices.Endpoints/Projects/Controllers/ProjectsAPIController.cs
@@ -170,22 +170,23 @@ public class ProjectsAPIController : ControllerBase
     {
         try
         {
-            var parms = new DynamicParameters();
-            parms.Add(@"@userid", 0, DbType.Int32);
-            parms.Add(@"@stattype", 0, DbType.Int32);
-            parms.Add(@"@flagtype", 0, DbType.Int32);
-            try
+            // Update the project status using a parameterized query to avoid SQL injection
+            const string updateQuery = "UPDATE Projects SET Status = @Status WHERE ProjectId = @ProjectId";
+            var updateParams = new { Status, ProjectId };
+
+            bool updateResult = await _unitOfWork.Project.ExecuteQueryAsync(updateQuery, updateParams);
+
+            if (updateResult)
             {
-                //var result = await _unitOfWork.Project.GetStoredProcedure("GetDashboardbyManager", parms);
-                var result = await _unitOfWork.Project.GetQueryAll<DashboardViewModel>(@"update projects set status=" + Status + " where projectid=" + ProjectId);
-                return StatusCode(StatusCodes.Status200OK, result);
+                return StatusCode(StatusCodes.Status200OK, new { success = true });
             }
-            catch (Exception ex) { return StatusCode(StatusCodes.Status500InternalServerError, ex); }
+
+            return StatusCode(StatusCodes.Status500InternalServerError, new { success = false });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, $"Error in retriving Attendance {nameof(GetProjects)}");
-            throw;
+            _logger.LogError(ex, $"Error in updating project status {nameof(ChangeProjectStatus)}");
+            return StatusCode(StatusCodes.Status500InternalServerError, new { success = false, message = ex.Message });
         }
     }
 


### PR DESCRIPTION
## Summary
- execute project status updates through a parameterised repository command and return a success flag
- ensure the VT home controller relays API status responses with correct HTTP codes
- surface the success flag on the dashboard JavaScript so the grid refreshes after a successful update

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e37ba1a69083228a0958aee45fad85