### PR TITLE
Add icon imagery for dashboard export buttons

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Home/_Dashboard/_ProjectTable.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Home/_Dashboard/_ProjectTable.cshtml
@@ -10,6 +10,52 @@
     .tblstatus {
         cursor: pointer;
     }
+
+    .dt-buttons {
+        margin-bottom: 1rem;
+    }
+
+    .dt-buttons .dt-button.export-action {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 8px;
+        border-radius: 0.5rem;
+        border: 1px solid #cbd5e1;
+        background-color: #ffffff;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+        transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+
+    .dt-buttons .dt-button.export-action:not(:last-child) {
+        margin-right: 0.75rem;
+    }
+
+    .dt-buttons .dt-button.export-action:hover,
+    .dt-buttons .dt-button.export-action:focus {
+        background-color: #f1f5f9;
+        box-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
+        transform: translateY(-1px);
+    }
+
+    .dt-buttons .dt-button.export-action img.export-icon {
+        display: block;
+        width: 36px;
+        height: 36px;
+    }
+
+    .dt-buttons .dt-button.export-action .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
 </style>
 <table class="table table-striped table-borderless">
     <thead>
@@ -135,13 +181,23 @@
             buttons: [
                 {
                     extend: 'excelHtml5',
-                    text: 'Export to Excel',
-                    title: 'Data_Export' // File name
+                    text: '<span class="sr-only">Export to Excel</span><img src="@Url.Content("~/theme/images/export-excel.svg")" class="export-icon" alt="Export to Excel" />',
+                    title: 'Data_Export', // File name
+                    className: 'export-action',
+                    attr: {
+                        'title': 'Export to Excel',
+                        'aria-label': 'Export to Excel'
+                    }
                 },
                 {
                     extend: 'csvHtml5',
-                    text: 'Export to CSV',
-                    title: 'Data_Export' // File name
+                    text: '<span class="sr-only">Export to CSV</span><img src="@Url.Content("~/theme/images/export-csv.svg")" class="export-icon" alt="Export to CSV" />',
+                    title: 'Data_Export', // File name
+                    className: 'export-action',
+                    attr: {
+                        'title': 'Export to CSV',
+                        'aria-label': 'Export to CSV'
+                    }
                 }
             ]
         });

--- a/src/NextOnServices.WebUI/wwwroot/theme/images/export-csv.svg
+++ b/src/NextOnServices.WebUI/wwwroot/theme/images/export-csv.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="csvGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6ee7b7" />
+      <stop offset="100%" stop-color="#10b981" />
+    </linearGradient>
+  </defs>
+  <path d="M44 12h44l28 28v64c0 11.046-8.954 20-20 20H44c-11.046 0-20-8.954-20-20V32c0-11.046 8.954-20 20-20z" fill="url(#csvGradient)" />
+  <path d="M88 12v24h24" fill="#bbf7d0" />
+  <path d="M36 36h56c6.627 0 12 5.373 12 12v48c0 6.627-5.373 12-12 12H36c-6.627 0-12-5.373-12-12V48c0-6.627 5.373-12 12-12z" fill="#ffffff" />
+  <text x="64" y="60" text-anchor="middle" font-family="'Poppins', 'Segoe UI', Arial, sans-serif" font-size="26" font-weight="700" fill="#10b981">CSV</text>
+  <rect x="44" y="74" width="40" height="8" rx="4" fill="#34d399" />
+  <rect x="44" y="90" width="40" height="8" rx="4" fill="#86efac" />
+  <rect x="44" y="106" width="40" height="8" rx="4" fill="#bbf7d0" />
+</svg>

--- a/src/NextOnServices.WebUI/wwwroot/theme/images/export-excel.svg
+++ b/src/NextOnServices.WebUI/wwwroot/theme/images/export-excel.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="excelGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e" />
+      <stop offset="100%" stop-color="#047857" />
+    </linearGradient>
+  </defs>
+  <rect x="12" y="12" width="104" height="104" rx="18" fill="url(#excelGradient)" />
+  <rect x="68" y="12" width="48" height="48" rx="12" fill="rgba(255,255,255,0.16)" />
+  <rect x="12" y="68" width="48" height="48" rx="12" fill="rgba(255,255,255,0.16)" />
+  <path d="M40 34 L88 82" stroke="#ffffff" stroke-width="16" stroke-linecap="round" />
+  <path d="M88 34 L40 82" stroke="#ffffff" stroke-width="16" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
## Summary
- style the DataTables export buttons so they display the new icon artwork instead of plain text
- add accessibility attributes and hover states to the export actions
- include SVG assets for the Excel and CSV export buttons

## Testing
- ⚠️ `DOTNET_ENVIRONMENT=Development dotnet run --project src/NextOnServices.WebUI/NextOnServices.WebUI.csproj --urls=http://0.0.0.0:5000` *(fails: command not found: dotnet in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a49f43b8832280fca7ff6cacfee1