### PR TITLE
Make supplier dashboard cards dynamic

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Controllers/SupplierController.cs
+++ b/src/NextOnServices.WebUI/Areas/VT/Controllers/SupplierController.cs
@@ -26,6 +26,7 @@ using Newtonsoft.Json.Linq;
 using NextOnServices.Infrastructure.ViewModels;
 using NuGet.Protocol.Core.Types;
 using System.Drawing.Printing;
+using System.Linq;
 
 
 
@@ -64,11 +65,16 @@ public class SupplierController : Controller
             {
                 dto.Supplier = (SupplierDTO?)((Microsoft.AspNetCore.Mvc.ObjectResult)res).Value;
             }
-            //var resProjects = await _suppliersAPIController.GetSupplierProjectsBySupplierId(Convert.ToInt32(SupplierId));
-            //if (resProjects != null && ((Microsoft.AspNetCore.Mvc.ObjectResult)resProjects).StatusCode == 200)
-            //{
-            //    dto.SupplierProjects = (List<SupplierProjectsDTO>?)((Microsoft.AspNetCore.Mvc.ObjectResult)resProjects).Value;
-            //}
+            var resProjects = await _suppliersAPIController.GetSupplierProjectsBySupplierId1(Convert.ToInt32(SupplierId));
+            if (resProjects is ObjectResult projectsResult && projectsResult.StatusCode == 200)
+            {
+                dto.SupplierProjects = projectsResult.Value as List<SupplierProjectsDTO>;
+                if (dto.SupplierProjects != null && dto.SupplierProjects.Any())
+                {
+                    dto.ProjectsInvoicedCount = dto.SupplierProjects.Count(x => x.Status == 6);
+                    dto.ProjectsCompletedCount = dto.ProjectsInvoicedCount;
+                }
+            }
         }
         return View(dto);
     }

--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -247,7 +247,7 @@
                     </div>
                     <div class="metric-content">
                         <h5>Projects Invoiced</h5>
-                        <div class="metric-value">92</div>
+                        <div class="metric-value">@(Model?.ProjectsInvoicedCount ?? 0)</div>
                         <p class="metric-subtext">Successfully billed engagements</p>
                     </div>
                 </div>
@@ -259,7 +259,7 @@
                     </div>
                     <div class="metric-content">
                         <h5>Projects Completed</h5>
-                        <div class="metric-value">127</div>
+                        <div class="metric-value">@(Model?.ProjectsCompletedCount ?? 0)</div>
                         <p class="metric-subtext">Total successful project deliveries</p>
                     </div>
                 </div>
@@ -319,7 +319,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title"><i class="fas fa-building"></i> Supplier Name</h5>
-                        <p class="card-text">@Model?.Supplier?.SupplierCode</p>
+                        <p class="card-text mb-0">@Model?.Supplier?.SupplierCode</p>
                     </div>
                 </div>
             </div>
@@ -327,7 +327,15 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title"><i class="fas fa-info-circle"></i> Supplier Description</h5>
-                        <p class="card-text">@Model?.Supplier?.Name</p>
+                        <p class="card-text mb-0">@Model?.Supplier?.Name</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6 mb-4">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title"><i class="fas fa-check-circle"></i> Projects Completed</h5>
+                        <p class="card-text mb-0">@(Model?.ProjectsCompletedCount ?? 0)</p>
                     </div>
                 </div>
             </div>

--- a/src/NextOnServices/NextOnServices.Infrastructure/ViewModels/Supplier/SupplierDashboardViewModel.cs
+++ b/src/NextOnServices/NextOnServices.Infrastructure/ViewModels/Supplier/SupplierDashboardViewModel.cs
@@ -11,4 +11,6 @@ public class SupplierDashboardViewModel
 {
     public SupplierDTO? Supplier { get; set; }
     public List<SupplierProjectsDTO>? SupplierProjects { get; set; }
+    public int ProjectsInvoicedCount { get; set; }
+    public int ProjectsCompletedCount { get; set; }
 }


### PR DESCRIPTION
## Summary
- compute supplier invoiced/completed project counts in the dashboard controller
- expose the counts via the supplier dashboard view model and display them in the summary cards
- add a matching project completed card in the supplier info section

## Testing
- Not run (missing `dotnet` CLI in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5564c37ec83229211d4694306d353