### PR TITLE
Align supplier dashboard metric cards with existing layout

### DIFF
--- a/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
+++ b/src/NextOnServices.WebUI/Areas/VT/Views/Supplier/Dashboard.cshtml
@@ -43,46 +43,50 @@
         }
 
         .metric-card {
-            background: linear-gradient(135deg, #f7f9fc, #eef2f7);
-            border-radius: 18px;
-            padding: 20px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            border: 1px solid rgba(0, 0, 0, 0.08);
+            border-radius: 0.75rem;
+        }
+
+        .metric-card .card-body {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .metric-card .card-title {
             display: flex;
             align-items: center;
-            gap: 15px;
-            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
-            height: 100%;
-            border: 1px solid rgba(0, 0, 0, 0.05);
+            gap: 0.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            color: #1b263b;
+            margin-bottom: 0.25rem;
         }
 
         .metric-icon {
-            width: 56px;
-            height: 56px;
-            border-radius: 14px;
-            display: flex;
+            display: inline-flex;
             align-items: center;
             justify-content: center;
-            font-size: 1.6rem;
-            color: #0d6efd;
+            width: 36px;
+            height: 36px;
+            border-radius: 0.5rem;
             background: rgba(13, 110, 253, 0.12);
-        }
-
-        .metric-content h5 {
-            font-size: 1rem;
-            font-weight: 600;
-            margin-bottom: 6px;
-            color: #1b263b;
+            color: #0d6efd;
+            font-size: 1.2rem;
         }
 
         .metric-value {
             font-size: 1.4rem;
             font-weight: 700;
             color: #0d6efd;
+            margin-bottom: 0;
         }
 
         .metric-subtext {
             font-size: 0.9rem;
             color: #6c757d;
-            margin: 0;
+            margin-bottom: 0;
         }
 
         .card {
@@ -241,73 +245,73 @@
 
         <div class="row dashboard-summary">
             <div class="col-lg-4 col-md-6 mb-4">
-                <div class="metric-card">
-                    <div class="metric-icon">
-                        <i class="fas fa-file-invoice-dollar"></i>
-                    </div>
-                    <div class="metric-content">
-                        <h5>Projects Invoiced</h5>
-                        <div class="metric-value">92</div>
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <span class="metric-icon"><i class="fas fa-file-invoice-dollar"></i></span>
+                            Projects Invoiced
+                        </h5>
+                        <p class="metric-value">92</p>
                         <p class="metric-subtext">Successfully billed engagements</p>
                     </div>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 mb-4">
-                <div class="metric-card">
-                    <div class="metric-icon">
-                        <i class="fas fa-check-circle"></i>
-                    </div>
-                    <div class="metric-content">
-                        <h5>Projects Completed</h5>
-                        <div class="metric-value">127</div>
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <span class="metric-icon"><i class="fas fa-check-circle"></i></span>
+                            Projects Completed
+                        </h5>
+                        <p class="metric-value">127</p>
                         <p class="metric-subtext">Total successful project deliveries</p>
                     </div>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 mb-4">
-                <div class="metric-card">
-                    <div class="metric-icon">
-                        <i class="fas fa-stopwatch"></i>
-                    </div>
-                    <div class="metric-content">
-                        <h5>Avg. Duration</h5>
-                        <div class="metric-value">45 days</div>
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <span class="metric-icon"><i class="fas fa-stopwatch"></i></span>
+                            Avg. Duration
+                        </h5>
+                        <p class="metric-value">45 days</p>
                         <p class="metric-subtext">Average project completion time</p>
                     </div>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 mb-4">
-                <div class="metric-card">
-                    <div class="metric-icon">
-                        <i class="fas fa-dollar-sign"></i>
-                    </div>
-                    <div class="metric-content">
-                        <h5>Avg. Project Value</h5>
-                        <div class="metric-value">$12,500</div>
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <span class="metric-icon"><i class="fas fa-dollar-sign"></i></span>
+                            Avg. Project Value
+                        </h5>
+                        <p class="metric-value">$12,500</p>
                         <p class="metric-subtext">Average value per engagement</p>
                     </div>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 mb-4">
-                <div class="metric-card">
-                    <div class="metric-icon">
-                        <i class="fas fa-globe"></i>
-                    </div>
-                    <div class="metric-content">
-                        <h5>Countries Covered</h5>
-                        <div class="metric-value">23</div>
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <span class="metric-icon"><i class="fas fa-globe"></i></span>
+                            Countries Covered
+                        </h5>
+                        <p class="metric-value">23</p>
                         <p class="metric-subtext">Global reach and coverage</p>
                     </div>
                 </div>
             </div>
             <div class="col-lg-4 col-md-6 mb-4">
-                <div class="metric-card">
-                    <div class="metric-icon">
-                        <i class="fas fa-calendar-check"></i>
-                    </div>
-                    <div class="metric-content">
-                        <h5>Supplier Since</h5>
-                        <div class="metric-value">15/06/2018</div>
+                <div class="card metric-card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <span class="metric-icon"><i class="fas fa-calendar-check"></i></span>
+                            Supplier Since
+                        </h5>
+                        <p class="metric-value">15/06/2018</p>
                         <p class="metric-subtext">7 years of partnership</p>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- restyle the dashboard metric cards to reuse the legacy Bootstrap card appearance
- adjust metric card structure to present icon, title, and values in a stacked two-line orientation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5595ca73483228d4a797b5964a561